### PR TITLE
fix issue with uninitialized upload files state.

### DIFF
--- a/BridgeSDK/BridgeAPI/SBBUploadManager.m
+++ b/BridgeSDK/BridgeAPI/SBBUploadManager.m
@@ -131,6 +131,9 @@ static NSString *kUploadSessionsKey = @"SBBUploadSessionsKey";
     if (tempFileURL) {
         NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
         NSMutableDictionary *filesForTempFiles = [[defaults dictionaryForKey:kUploadFilesKey] mutableCopy];
+        if (!filesForTempFiles) {
+            filesForTempFiles = [NSMutableDictionary dictionary];
+        }
         [filesForTempFiles setObject:[fileURL path] forKey:[tempFileURL path]];
         [defaults setObject:filesForTempFiles forKey:kUploadFilesKey];
         [defaults synchronize];


### PR DESCRIPTION
In testing the background URL callbacks on my AppDelegate, I found that the file URL was nil (specifically, to callback `uploadManager(_ manager: SBBUploadManager!, uploadOfFile file: String!, completedWithError error: Error!)`). It seems the root cause is that this dictionary is never initialized. Since the other state parameters used by the `SBBUploadManager` are initialized if empty, I've done the same here.